### PR TITLE
Certificate is new API parameter.

### DIFF
--- a/src/UlozenkaLib/APIv3/Api.php
+++ b/src/UlozenkaLib/APIv3/Api.php
@@ -38,6 +38,7 @@ class Api
     private $apiKey;
     private $appId;
     private $appVersion;
+    private $certificatePath;
 
     /**
      * Api constructor.
@@ -47,7 +48,7 @@ class Api
      * @param string|null $appId
      * @param string|null $appVersion
      */
-    public function __construct($endpoint = Endpoint::PRODUCTION, $shopId = null, $apiKey = null, $appId = null, $appVersion = null)
+    public function __construct($endpoint = Endpoint::PRODUCTION, $shopId = null, $apiKey = null, $appId = null, $appVersion = null, $certificatePath = null)
     {
         $this->connector = new Connector($endpoint);
         $this->shopId = $shopId;
@@ -55,6 +56,9 @@ class Api
         $this->appId = $appId;
         $this->appVersion = $appVersion;
         $this->formatter = new JsonFormatter();
+        if ($certificatePath != null) {
+            $this->connector->setCertificate($certificatePath);
+        }
     }
 
     /**

--- a/src/UlozenkaLib/APIv3/Connector.php
+++ b/src/UlozenkaLib/APIv3/Connector.php
@@ -38,6 +38,11 @@ class Connector
         $this->curlOptions[CURLOPT_SSL_VERIFYPEER] = false;
     }
 
+    public function setCertificate($certificatePath)
+    {
+        $this->curlOptions[CURLOPT_CAINFO] = $certificatePath;
+    }
+
     /**
      *
      * @return string


### PR DESCRIPTION
Recently, our ulozenka uploader module stopped working because of failing certificate (error message: SSL certificate problem: unable to get local issuer certificate).

Our hosting provider doesn't allow any changes in certificates in php.ini so I have to set this certificate directly to the cURL request.

I created an additional setter for connector + wiring up to the API constructor.

Best regards
Jan Herzan